### PR TITLE
Handle MBO snapshot messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ The system achieves:
 - >17 million messages per second throughput
 - Efficient memory usage through mmap and batch processing
 
+## Handling snapshot messages
+
+Databento sets a `SNAPSHOT` flag on records that originate from a replay or
+snapshot server. The flag constant is defined in `dbn::flags`:
+
+```rust
+pub const SNAPSHOT: u8 = 1 << 5;
+```
+as shown in the Databento source【F:docs/mbo_flags_snippet.txt†L1-L9】.
+Snapshot messages are applied the same way as live updates, typically starting
+with a `Clear` action followed by `Add` actions that rebuild the order book.
+The included unit test demonstrates clearing the book and applying orders from a
+snapshot.
+
 ## Architecture
 
 - **Producer thread**: Memory-maps files and decodes compressed market data

--- a/docs/mbo_flags_snippet.txt
+++ b/docs/mbo_flags_snippet.txt
@@ -1,0 +1,7 @@
+   900	    /// Indicates it's the last message in the packet from the venue for a given
+   901	    /// `instrument_id`.
+   902	    pub const LAST: u8 = 1 << 7;
+   903	    /// Indicates a top-of-book message, not an individual order.
+   904	    pub const TOB: u8 = 1 << 6;
+   905	    /// Indicates the message was sourced from a replay, such as a snapshot server.
+   906	    pub const SNAPSHOT: u8 = 1 << 5;

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -1,0 +1,33 @@
+use algotrading::lob::Book;
+use databento::dbn::{record::{MboMsg, RecordHeader}, enums::{Action, Side}, FlagSet};
+
+fn msg(order_id: u64, side: Side, action: Action, px: i64, sz: u32, snapshot: bool) -> MboMsg {
+    let mut flags = FlagSet::empty();
+    if snapshot { flags.set_snapshot(); }
+    MboMsg {
+        hd: RecordHeader::new::<MboMsg>(0, 0, 1, 0),
+        order_id,
+        price: px,
+        size: sz,
+        flags,
+        channel_id: 0,
+        action: Into::<u8>::into(action) as i8,
+        side: Into::<u8>::into(side) as i8,
+        ts_recv: 0,
+        ts_in_delta: 0,
+        sequence: 0,
+    }
+}
+
+#[test]
+fn snapshot_clear_then_add() {
+    let mut book = Book::default();
+
+    book.apply(msg(1, Side::Bid, Action::Add, 100, 10, false));
+    book.apply(msg(0, Side::Bid, Action::Clear, 0, 0, true));
+    book.apply(msg(2, Side::Bid, Action::Add, 110, 5, true));
+
+    let (bid, ask) = book.bbo();
+    assert_eq!(bid.unwrap().price, 110);
+    assert!(ask.is_none());
+}


### PR DESCRIPTION
## Summary
- add a unit test showing how snapshot CLEAR/ADD messages reset the book
- document the SNAPSHOT flag constant from Databento
- include snippet from Databento enums describing SNAPSHOT

## Testing
- `cargo test --tests`

------
https://chatgpt.com/codex/tasks/task_e_6842e4a00aa0832ba8e6271ce0715b74