### PR TITLE
Improve cancel logic and add limit order book tests

### DIFF
--- a/src/lob.rs
+++ b/src/lob.rs
@@ -1,21 +1,21 @@
 use databento::dbn::{
-    enums::{Action, Side},
-    record::MboMsg,
     UNDEF_PRICE,
+    enums::{Action, Side},
     pretty,
+    record::MboMsg,
 };
 use hashbrown::HashMap;
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 use std::collections::BTreeMap;
 use std::fmt::Display;
 
 /* ---------- fast container aliases ---------------------------------- */
-type OrderMap    = HashMap<u64, (Side, i64)>;
-type Level       = SmallVec<[MboMsg; 8]>;
+type OrderMap = HashMap<u64, (Side, i64)>;
+type Level = SmallVec<[MboMsg; 8]>;
 type PriceLevels = BTreeMap<i64, Level>;
 
 pub type Publisher = u8;
-pub type InstId    = u32;
+pub type InstId = u32;
 
 /* ---------- helper -------------------------------------------------- */
 fn agg(lvl: &Level) -> (u32, u32) {
@@ -28,7 +28,11 @@ fn agg(lvl: &Level) -> (u32, u32) {
 /*  BOOK – one instrument *and* one publisher                            */
 /* ==================================================================== */
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LevelSummary { pub price: i64, pub size: u32, pub count: u32 }
+pub struct LevelSummary {
+    pub price: i64,
+    pub size: u32,
+    pub count: u32,
+}
 
 impl Display for LevelSummary {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -53,39 +57,57 @@ impl Book {
     pub fn bbo(&self) -> (Option<LevelSummary>, Option<LevelSummary>) {
         let bid = self.bids.iter().next_back().map(|(px, l)| {
             let (sz, ct) = agg(l);
-            LevelSummary { price: *px, size: sz, count: ct }
+            LevelSummary {
+                price: *px,
+                size: sz,
+                count: ct,
+            }
         });
         let ask = self.asks.iter().next().map(|(px, l)| {
             let (sz, ct) = agg(l);
-            LevelSummary { price: *px, size: sz, count: ct }
+            LevelSummary {
+                price: *px,
+                size: sz,
+                count: ct,
+            }
         });
         (bid, ask)
     }
 
     pub fn apply(&mut self, mbo: MboMsg) {
         match mbo.action().unwrap() {
-            Action::Add    => self.add(mbo),
+            Action::Add => self.add(mbo),
             Action::Modify => self.modify(mbo),
             Action::Cancel => self.cancel(mbo),
-            Action::Clear  => self.clear(),
+            Action::Clear => self.clear(),
             _ => {}
         }
     }
 
     /* -------------- internal helpers -------------------------------- */
     fn side_levels_mut(&mut self, s: Side) -> &mut PriceLevels {
-        match s { Side::Bid => &mut self.bids, Side::Ask => &mut self.asks, Side::None => unreachable!() }
+        match s {
+            Side::Bid => &mut self.bids,
+            Side::Ask => &mut self.asks,
+            Side::None => unreachable!(),
+        }
     }
-    fn clear(&mut self) { self.orders_by_id.clear(); self.bids.clear(); self.asks.clear(); }
+    fn clear(&mut self) {
+        self.orders_by_id.clear();
+        self.bids.clear();
+        self.asks.clear();
+    }
 
     /* -------------- ADD --------------------------------------------- */
     fn add(&mut self, mbo: MboMsg) {
         let side = mbo.side().unwrap();
-        let px   = mbo.price;
+        let px = mbo.price;
         if mbo.flags.is_tob() {
             let levels = self.side_levels_mut(side);
             levels.clear();
-            if px != UNDEF_PRICE { levels.insert(px, smallvec![mbo]); }
+            if px != UNDEF_PRICE {
+                levels.insert(px, smallvec![mbo]);
+            }
             return;
         }
         self.orders_by_id.insert(mbo.order_id, (side, px));
@@ -94,16 +116,27 @@ impl Book {
 
     /* -------------- CANCEL ------------------------------------------ */
     fn cancel(&mut self, mbo: MboMsg) {
-        let (side, px) = match self.orders_by_id.remove(&mbo.order_id) {
+        let (side, px) = match self.orders_by_id.get(&mbo.order_id).copied() {
             Some(v) => v,
             None => return,
         };
+        let mut remove_mapping = false;
         if let Some(level) = self.side_levels_mut(side).get_mut(&px) {
             if let Some(pos) = level.iter().position(|o| o.order_id == mbo.order_id) {
                 let existing = &mut level[pos];
-                if mbo.size >= existing.size { level.remove(pos); } else { existing.size -= mbo.size; }
+                if mbo.size >= existing.size {
+                    level.remove(pos);
+                    remove_mapping = true;
+                } else {
+                    existing.size -= mbo.size;
+                }
             }
-            if level.is_empty() { self.side_levels_mut(side).remove(&px); }
+            if level.is_empty() {
+                self.side_levels_mut(side).remove(&px);
+            }
+        }
+        if remove_mapping {
+            self.orders_by_id.remove(&mbo.order_id);
         }
     }
 
@@ -114,7 +147,7 @@ impl Book {
             None => return self.add(mbo),
         };
         let new_side = mbo.side().unwrap();
-        let new_px   = mbo.price;
+        let new_px = mbo.price;
 
         if let Some(level) = self.side_levels_mut(old_side).get_mut(&old_px) {
             if let Some(idx) = level.iter().position(|o| o.order_id == mbo.order_id) {
@@ -126,9 +159,14 @@ impl Book {
                 }
 
                 let order = level.remove(idx);
-                if level.is_empty() { self.side_levels_mut(old_side).remove(&old_px); }
+                if level.is_empty() {
+                    self.side_levels_mut(old_side).remove(&old_px);
+                }
                 self.orders_by_id.insert(mbo.order_id, (new_side, new_px));
-                self.side_levels_mut(new_side).entry(new_px).or_default().push(order);
+                self.side_levels_mut(new_side)
+                    .entry(new_px)
+                    .or_default()
+                    .push(order);
                 return;
             }
         }
@@ -160,10 +198,10 @@ impl Market {
     }
 
     /// aggregated BBO per publisher → highest bid / lowest ask across pubs
-    pub fn aggregated_bbo(&self, inst: InstId)
-        -> (Option<LevelSummary>, Option<LevelSummary>)
-    {
-        let Some(list) = self.books.get(&inst) else { return (None,None); };
+    pub fn aggregated_bbo(&self, inst: InstId) -> (Option<LevelSummary>, Option<LevelSummary>) {
+        let Some(list) = self.books.get(&inst) else {
+            return (None, None);
+        };
         let mut best_bid: Option<LevelSummary> = None;
         let mut best_ask: Option<LevelSummary> = None;
 
@@ -173,7 +211,10 @@ impl Market {
                 match &mut best_bid {
                     None => best_bid = Some(b),
                     Some(bb) if b.price > bb.price => best_bid = Some(b),
-                    Some(bb) if b.price == bb.price => { bb.size += b.size; bb.count += b.count; }
+                    Some(bb) if b.price == bb.price => {
+                        bb.size += b.size;
+                        bb.count += b.count;
+                    }
                     _ => {}
                 }
             }
@@ -181,7 +222,10 @@ impl Market {
                 match &mut best_ask {
                     None => best_ask = Some(a),
                     Some(aa) if a.price < aa.price => best_ask = Some(a),
-                    Some(aa) if a.price == aa.price => { aa.size += a.size; aa.count += a.count; }
+                    Some(aa) if a.price == aa.price => {
+                        aa.size += a.size;
+                        aa.count += a.count;
+                    }
                     _ => {}
                 }
             }

--- a/tests/lob.rs
+++ b/tests/lob.rs
@@ -1,0 +1,102 @@
+use algotrading::lob::{Book, Market};
+use databento::dbn::{
+    FlagSet,
+    enums::{Action, Side},
+    record::{MboMsg, RecordHeader},
+};
+
+fn msg(order_id: u64, side: Side, action: Action, px: i64, sz: u32) -> MboMsg {
+    MboMsg {
+        hd: RecordHeader::new::<MboMsg>(0, 0, 1, 0),
+        order_id,
+        price: px,
+        size: sz,
+        flags: FlagSet::empty(),
+        channel_id: 0,
+        action: Into::<u8>::into(action) as i8,
+        side: Into::<u8>::into(side) as i8,
+        ts_recv: 0,
+        ts_in_delta: 0,
+        sequence: 0,
+    }
+}
+
+#[test]
+fn add_and_bbo() {
+    let mut book = Book::default();
+    book.apply(msg(1, Side::Bid, Action::Add, 100, 5));
+    book.apply(msg(2, Side::Ask, Action::Add, 110, 7));
+
+    let (bid, ask) = book.bbo();
+    assert_eq!(bid.unwrap().price, 100);
+    assert_eq!(ask.unwrap().price, 110);
+}
+
+#[test]
+fn modify_same_price_increase_size() {
+    let mut book = Book::default();
+    book.apply(msg(1, Side::Bid, Action::Add, 100, 5));
+    let mut m = msg(1, Side::Bid, Action::Modify, 100, 8);
+    book.apply(m);
+
+    let (bid, ask) = book.bbo();
+    assert_eq!(bid.unwrap().size, 8);
+    assert!(ask.is_none());
+}
+
+#[test]
+fn modify_change_price() {
+    let mut book = Book::default();
+    book.apply(msg(1, Side::Bid, Action::Add, 100, 5));
+    book.apply(msg(1, Side::Bid, Action::Modify, 90, 5));
+
+    let (bid, _) = book.bbo();
+    assert_eq!(bid.unwrap().price, 90);
+}
+
+#[test]
+fn cancel_partial_and_full() {
+    let mut book = Book::default();
+    book.apply(msg(1, Side::Bid, Action::Add, 100, 10));
+    book.apply(msg(1, Side::Bid, Action::Cancel, 100, 4));
+
+    let (bid, _) = book.bbo();
+    assert_eq!(bid.as_ref().unwrap().size, 6);
+
+    book.apply(msg(1, Side::Bid, Action::Cancel, 100, 6));
+    assert!(book.bbo().0.is_none());
+}
+
+#[test]
+fn top_of_book_clears() {
+    use databento::dbn::enums::flags;
+
+    let mut book = Book::default();
+    book.apply(msg(1, Side::Bid, Action::Add, 100, 5));
+
+    let mut flags = FlagSet::empty();
+    flags.set_tob();
+    let mut tob_msg = msg(0, Side::Bid, Action::Add, 101, 3);
+    tob_msg.flags = flags;
+    book.apply(tob_msg);
+
+    assert_eq!(book.bids.len(), 1);
+    assert_eq!(book.bbo().0.unwrap().price, 101);
+}
+
+#[test]
+fn market_aggregated_bbo() {
+    let mut market = Market::default();
+    let mut m1 = msg(1, Side::Bid, Action::Add, 100, 5);
+    m1.hd.instrument_id = 1;
+    m1.hd.publisher_id = 1;
+    market.apply(m1);
+
+    let mut m2 = msg(2, Side::Bid, Action::Add, 102, 4);
+    m2.hd.instrument_id = 1;
+    m2.hd.publisher_id = 2;
+    market.apply(m2);
+
+    let (bb, _) = market.aggregated_bbo(1);
+    assert_eq!(bb.unwrap().price, 102);
+}


### PR DESCRIPTION
## Summary
- fix order cancellation logic to keep orders until fully removed
- add comprehensive unit tests for limit order book behavior

## Testing
- `cargo test --test lob`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6842eef773e0832b95e994e75e961240