### PR TITLE
Remove external path from workspace

### DIFF
--- a/src/Rust.code-workspace
+++ b/src/Rust.code-workspace
@@ -1,11 +1,8 @@
 {
-	"folders": [
-		{
-			"path": "../.."
-		},
-		{
-			"path": "../../../../Downloads/GLBX-20250125-7EGB4J87MC"
-		}
-	],
-	"settings": {}
+  "folders": [
+    {
+      "path": "../.."
+    }
+  ],
+  "settings": {}
 }


### PR DESCRIPTION
## Summary
- clean up VSCode workspace by removing path to `~/Downloads/GLBX-20250125-7EGB4J87MC`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68430f27be34832bbdafc7262b69dfcc