### PR TITLE
Add instrument-isolated backtesting tests

### DIFF
--- a/src/backtest.rs
+++ b/src/backtest.rs
@@ -1,0 +1,105 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Signal {
+    Buy,
+    Sell,
+    Hold,
+}
+
+#[derive(Debug)]
+pub struct Backtester {
+    cash: f64,
+    position: i32,
+    equity: f64,
+}
+
+impl Backtester {
+    /// Create a new backtester with zero cash and no position.
+    pub fn new() -> Self {
+        Self {
+            cash: 0.0,
+            position: 0,
+            equity: 0.0,
+        }
+    }
+
+    /// Advance the simulation by one step with a price and trading signal.
+    /// Returns the reward (change in equity) after applying the signal.
+    pub fn step(&mut self, price: f64, signal: Signal) -> f64 {
+        match signal {
+            Signal::Buy => {
+                if self.position == 0 {
+                    self.cash -= price;
+                    self.position = 1;
+                }
+            }
+            Signal::Sell => {
+                if self.position == 1 {
+                    self.cash += price;
+                    self.position = 0;
+                }
+            }
+            Signal::Hold => {}
+        }
+        let new_equity = self.cash + self.position as f64 * price;
+        let reward = new_equity - self.equity;
+        self.equity = new_equity;
+        reward
+    }
+
+    /// Advance the simulation using the aggregated BBO from an [`Market`].
+    /// Returns `None` if no quote is available for the given instrument.
+    pub fn step_mbo(
+        &mut self,
+        market: &crate::lob::Market,
+        inst: crate::lob::InstId,
+        signal: Signal,
+    ) -> Option<f64> {
+        let (bid, ask) = market.aggregated_bbo(inst);
+        let px = match (bid, ask) {
+            (Some(b), Some(a)) => (b.price + a.price) as f64 / 2.0,
+            _ => return None,
+        };
+        Some(self.step(px, signal))
+    }
+
+    /// Run a backtest over a series of prices and signals.
+    /// Returns the reward at each step.
+    pub fn run(&mut self, prices: &[f64], signals: &[Signal]) -> Vec<f64> {
+        assert_eq!(prices.len(), signals.len());
+        let mut rewards = Vec::with_capacity(prices.len());
+        for (&p, &s) in prices.iter().zip(signals) {
+            rewards.push(self.step(p, s));
+        }
+        rewards
+    }
+
+    /// Compute the final profit at the given price.
+    pub fn final_profit(&self, price: f64) -> f64 {
+        self.cash + self.position as f64 * price
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_buy_sell() {
+        let prices = [10.0, 12.0, 11.0];
+        let signals = [Signal::Buy, Signal::Hold, Signal::Sell];
+        let mut bt = Backtester::new();
+        let rewards = bt.run(&prices, &signals);
+        assert_eq!(rewards.len(), 3);
+        let profit = bt.final_profit(prices[2]);
+        assert!((profit - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn reward_sequence() {
+        let prices = [1.0, 2.0, 3.0];
+        let signals = [Signal::Hold, Signal::Buy, Signal::Hold];
+        let mut bt = Backtester::new();
+        let rewards = bt.run(&prices, &signals);
+        assert_eq!(rewards, vec![0.0, 0.0, 1.0]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,4 @@
 
 pub mod lob;          // order book logic
 pub mod features;    // feature extraction utilities
+pub mod backtest;   // strategy backtesting utilities

--- a/tests/backtest.rs
+++ b/tests/backtest.rs
@@ -1,0 +1,52 @@
+use algotrading::backtest::{Backtester, Signal};
+
+#[test]
+fn profit_after_round_trip() {
+    let prices = [10.0, 12.0, 11.0];
+    let signals = [Signal::Buy, Signal::Hold, Signal::Sell];
+    let mut bt = Backtester::new();
+    bt.run(&prices, &signals);
+    let pnl = bt.final_profit(prices[2]);
+    assert!((pnl - 1.0).abs() < 1e-6);
+}
+use algotrading::lob::{Market, InstId};
+use databento::dbn::{record::{MboMsg, RecordHeader}, enums::{Action, Side}, FlagSet};
+
+fn msg(order_id: u64, side: Side, action: Action, px: i64, sz: u32, inst: InstId) -> MboMsg {
+    let mut m = MboMsg {
+        hd: RecordHeader::new::<MboMsg>(0, 0, inst, 0),
+        order_id,
+        price: px,
+        size: sz,
+        flags: FlagSet::empty(),
+        channel_id: 0,
+        action: Into::<u8>::into(action) as i8,
+        side: Into::<u8>::into(side) as i8,
+        ts_recv: 0,
+        ts_in_delta: 0,
+        sequence: 0,
+    };
+    m.hd.publisher_id = 1;
+    m
+}
+
+#[test]
+fn step_mbo_isolated() {
+    let mut market = Market::default();
+    market.apply(msg(1, Side::Bid, Action::Add, 100, 1, 1));
+    market.apply(msg(2, Side::Ask, Action::Add, 110, 1, 1));
+    market.apply(msg(3, Side::Bid, Action::Add, 200, 1, 2));
+    market.apply(msg(4, Side::Ask, Action::Add, 210, 1, 2));
+
+    let mut bt1 = Backtester::new();
+    let mut bt2 = Backtester::new();
+
+    let _ = bt1.step_mbo(&market, 1, Signal::Buy).unwrap();
+    let pnl1 = bt1.final_profit(105.0);
+    let _ = bt2.step_mbo(&market, 2, Signal::Buy).unwrap();
+
+    // backtester for instrument 1 unaffected by instrument 2
+    assert!((bt1.final_profit(105.0) - pnl1).abs() < 1e-6);
+    assert!(bt2.final_profit(205.0).abs() < 1e-6);
+}
+

--- a/tests/features.rs
+++ b/tests/features.rs
@@ -70,3 +70,20 @@ fn depth_sorted_by_price() {
     assert_eq!(depth[1].price, 100);
     assert_eq!(depth[2].price, 99);
 }
+#[test]
+fn instruments_are_isolated() {
+    let mut market = Market::default();
+    let bid = msg(1, Side::Bid, Action::Add, 100, 5, 1, 1);
+    market.apply(bid);
+    let ask_other = msg(2, Side::Ask, Action::Add, 200, 7, 1, 2);
+    market.apply(ask_other);
+
+    let f1 = market.extract_features(1, DEFAULT_LEVELS).unwrap();
+    assert_eq!(f1.bid_sizes, vec![5]);
+    assert!(f1.ask_sizes.is_empty());
+
+    let f2 = market.extract_features(2, DEFAULT_LEVELS).unwrap();
+    assert_eq!(f2.ask_sizes, vec![7]);
+    assert!(f2.bid_sizes.is_empty());
+}
+


### PR DESCRIPTION
## Summary
- handle market data in the backtester via `step_mbo`
- add unit tests verifying features and backtesting remain isolated per instrument

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684322123bc8832baffb465521672a98