### PR TITLE
Handle snapshot messages correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Snapshot messages are applied the same way as live updates, typically starting
 with a `Clear` action followed by `Add` actions that rebuild the order book.
 The included unit test demonstrates clearing the book and applying orders from a
 snapshot.
+Trading strategies and feature extraction skip these messages when generating
+signals so that only real-time updates influence decisions.
 
 ## Architecture
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,4 @@ pub mod backtest; // strategy backtesting utilities
 pub mod features; // feature extraction utilities
 pub mod lob; // order book logic
 pub mod metrics; // performance evaluation helpers
+pub mod strategy; // example trading strategies

--- a/src/lob.rs
+++ b/src/lob.rs
@@ -248,7 +248,9 @@ impl Market {
     #[allow(dead_code)]
     pub fn aggregated_depth(&self, inst: InstId, side: Side, levels: usize) -> Vec<LevelSummary> {
         use std::collections::BTreeMap;
-        let Some(list) = self.books.get(&inst) else { return Vec::new() };
+        let Some(list) = self.books.get(&inst) else {
+            return Vec::new();
+        };
         let mut map: BTreeMap<i64, LevelSummary> = BTreeMap::new();
         for (_, book) in list {
             let it: Box<dyn Iterator<Item = (&i64, &SmallVec<[MboMsg; 8]>)>> = match side {
@@ -261,7 +263,11 @@ impl Market {
                     .iter()
                     .filter(|m| !m.flags.is_tob())
                     .fold((0, 0), |acc, m| (acc.0 + m.size, acc.1 + 1));
-                let entry = map.entry(*px).or_insert(LevelSummary { price: *px, size: 0, count: 0 });
+                let entry = map.entry(*px).or_insert(LevelSummary {
+                    price: *px,
+                    size: 0,
+                    count: 0,
+                });
                 entry.size += sz;
                 entry.count += ct;
             }

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -1,0 +1,125 @@
+use crate::lob::Market;
+use databento::dbn::{enums::Action, record::MboMsg};
+use std::collections::VecDeque;
+
+/// Possible actions returned by [`HelloStrategy`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TradeAction {
+    /// Enter a long position.
+    Long,
+    /// Enter a short position.
+    Short,
+    /// Exit any open position.
+    Flatten,
+    /// Do nothing.
+    Hold,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Position {
+    Flat,
+    Long,
+    Short,
+}
+
+/// A minimal example trading strategy.
+///
+/// The strategy keeps a rolling mean of the last `window` trade prices. On
+/// every trade message it compares the current mid price to this mean and
+/// generates `TradeAction`s to go long, short, flatten, or hold.
+#[derive(Debug)]
+pub struct HelloStrategy {
+    market: Market,
+    window: usize,
+    trades: VecDeque<f64>,
+    position: Position,
+}
+
+impl HelloStrategy {
+    /// Create a new strategy with the specified rolling window size.
+    pub fn new(window: usize) -> Self {
+        Self {
+            market: Market::default(),
+            window,
+            trades: VecDeque::with_capacity(window),
+            position: Position::Flat,
+        }
+    }
+
+    fn rolling_mean(&self) -> Option<f64> {
+        if self.trades.is_empty() {
+            None
+        } else {
+            Some(self.trades.iter().sum::<f64>() / self.trades.len() as f64)
+        }
+    }
+
+    /// Process an incoming [`MboMsg`].
+    ///
+    /// Non-trade messages update the internal book state and return `Hold`.
+    /// When a trade message is encountered, the book is updated and the current
+    /// mid price is compared to the rolling mean of recent trades to produce a
+    /// [`TradeAction`].
+    pub fn on_message(&mut self, msg: MboMsg) -> TradeAction {
+        let inst = msg.hd.instrument_id;
+
+        // Always update the internal book state, even for snapshot messages
+        self.market.apply(msg.clone());
+
+        // Skip trade logic on snapshot messages
+        if msg.flags.is_snapshot() {
+            return TradeAction::Hold;
+        }
+
+        if msg.action().unwrap_or(Action::None) != Action::Trade {
+            return TradeAction::Hold;
+        }
+
+        // update rolling trade history
+        let price = msg.price as f64;
+        self.trades.push_back(price);
+        if self.trades.len() > self.window {
+            self.trades.pop_front();
+        }
+        let mean = match self.rolling_mean() {
+            Some(m) => m,
+            None => return TradeAction::Hold,
+        };
+
+        let (bid, ask) = self.market.aggregated_bbo(inst);
+        let (Some(b), Some(a)) = (bid, ask) else {
+            return TradeAction::Hold;
+        };
+        let mid = (b.price + a.price) as f64 / 2.0;
+
+        match self.position {
+            Position::Flat => {
+                if mid > mean {
+                    self.position = Position::Long;
+                    TradeAction::Long
+                } else if mid < mean {
+                    self.position = Position::Short;
+                    TradeAction::Short
+                } else {
+                    TradeAction::Hold
+                }
+            }
+            Position::Long => {
+                if mid < mean {
+                    self.position = Position::Flat;
+                    TradeAction::Flatten
+                } else {
+                    TradeAction::Hold
+                }
+            }
+            Position::Short => {
+                if mid > mean {
+                    self.position = Position::Flat;
+                    TradeAction::Flatten
+                } else {
+                    TradeAction::Hold
+                }
+            }
+        }
+    }
+}

--- a/tests/strategy.rs
+++ b/tests/strategy.rs
@@ -1,0 +1,121 @@
+use algotrading::strategy::{HelloStrategy, TradeAction};
+use databento::dbn::{
+    FlagSet,
+    enums::{Action, Side},
+    record::{MboMsg, RecordHeader},
+};
+
+fn msg(order_id: u64, side: Side, action: Action, px: i64, sz: u32, inst: u32) -> MboMsg {
+    let mut m = MboMsg {
+        hd: RecordHeader::new::<MboMsg>(0, 0, inst, 0),
+        order_id,
+        price: px,
+        size: sz,
+        flags: FlagSet::empty(),
+        channel_id: 0,
+        action: Into::<u8>::into(action) as i8,
+        side: Into::<u8>::into(side) as i8,
+        ts_recv: 0,
+        ts_in_delta: 0,
+        sequence: 0,
+    };
+    m.hd.publisher_id = 1;
+    m
+}
+
+#[test]
+fn basic_flow() {
+    let mut strat = HelloStrategy::new(2);
+
+    // Seed book state
+    strat.on_message(msg(1, Side::Bid, Action::Add, 99, 1, 1));
+    strat.on_message(msg(2, Side::Ask, Action::Add, 101, 1, 1));
+
+    // First trade -> mean 101, mid 100 -> short
+    let act = strat.on_message(msg(0, Side::Bid, Action::Trade, 101, 1, 1));
+    assert_eq!(act, TradeAction::Short);
+
+    // Second trade -> mean 99.5, mid 100 -> flatten
+    let act = strat.on_message(msg(0, Side::Bid, Action::Trade, 98, 1, 1));
+    assert_eq!(act, TradeAction::Flatten);
+
+    // Third trade -> mean 100, mid 100 -> hold
+    let act = strat.on_message(msg(0, Side::Bid, Action::Trade, 102, 1, 1));
+    assert_eq!(act, TradeAction::Hold);
+}
+
+#[test]
+fn ignore_snapshot_messages() {
+    let mut strat = HelloStrategy::new(2);
+
+    let mut s1 = msg(1, Side::Bid, Action::Add, 99, 1, 1);
+    s1.flags.set_snapshot();
+    assert_eq!(strat.on_message(s1), TradeAction::Hold);
+
+    let mut s2 = msg(2, Side::Ask, Action::Add, 101, 1, 1);
+    s2.flags.set_snapshot();
+    assert_eq!(strat.on_message(s2), TradeAction::Hold);
+
+    // subsequent live trade should trigger normally using the snapshot state
+    let act = strat.on_message(msg(0, Side::Bid, Action::Trade, 101, 1, 1));
+    assert_eq!(act, TradeAction::Short);
+}
+
+#[test]
+fn pnl_of_example() {
+    use algotrading::lob::Market;
+
+    let mut strat = HelloStrategy::new(2);
+    let mut market = Market::default();
+
+    let mut cash = 0.0;
+    let mut position: i32 = 0;
+
+    let mut step = |m: MboMsg| {
+        market.apply(m.clone());
+        let act = strat.on_message(m);
+        let (bid, ask) = market.aggregated_bbo(1);
+        let (Some(b), Some(a)) = (bid, ask) else {
+            return;
+        };
+        let mid = (b.price + a.price) as f64 / 2.0;
+        match act {
+            TradeAction::Long => {
+                cash -= mid;
+                position = 1;
+            }
+            TradeAction::Short => {
+                cash += mid;
+                position = -1;
+            }
+            TradeAction::Flatten => {
+                cash += position as f64 * mid;
+                position = 0;
+            }
+            TradeAction::Hold => {}
+        }
+    };
+
+    // seed BBO
+    step(msg(1, Side::Bid, Action::Add, 100, 1, 1));
+    step(msg(2, Side::Ask, Action::Add, 102, 1, 1));
+
+    // first trade opens a long position
+    step(msg(0, Side::Bid, Action::Trade, 99, 1, 1));
+
+    // move the ask higher
+    step(msg(2, Side::Ask, Action::Modify, 120, 1, 1));
+
+    // more trades update the rolling mean
+    step(msg(0, Side::Bid, Action::Trade, 118, 1, 1));
+    step(msg(0, Side::Bid, Action::Trade, 200, 1, 1));
+
+    let (bid, ask) = market.aggregated_bbo(1);
+    let (Some(b), Some(a)) = (bid, ask) else {
+        panic!("no mid")
+    };
+    let final_mid = (b.price + a.price) as f64 / 2.0;
+    let pnl = cash + position as f64 * final_mid;
+
+    assert!((pnl - 9.0).abs() < 1e-6);
+}


### PR DESCRIPTION
## Summary
- remove unused `apply_live` helper
- update `HelloStrategy` to build its book from snapshots but not trade on them
- clarify snapshot section in README
- revise snapshot test expectations

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6843340dac20832bb58521ac0fb08715